### PR TITLE
feat: Implement Debug Logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonoransoftware/sonoran.js",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Sonoran.js is a library that allows you to interact with the Sonoran CAD and Sonoran CMS API. Based off of and utilizes several Discord.js library techniques for ease of use.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/libs/rest/src/lib/RequestManager.ts
+++ b/src/libs/rest/src/lib/RequestManager.ts
@@ -253,4 +253,8 @@ export class RequestManager extends EventEmitter {
 
     return apiData;
   }
+
+  debug(log: string) {
+    return this.instance._debugLog(log);
+  }
 }

--- a/src/libs/rest/src/lib/handlers/SequentialHandler.ts
+++ b/src/libs/rest/src/lib/handlers/SequentialHandler.ts
@@ -114,6 +114,8 @@ export class SequentialHandler implements IHandler {
 		const timeout = setTimeout(() => controller.abort(), 30000).unref();
 		let res: Response;
 
+		void this.manager.debug(`[${url} Request] - ${JSON.stringify({ url, options, data })}`);
+
 		try {
 			// node-fetch typings are a bit weird, so we have to cast to any to get the correct signature
 			// Type 'AbortSignal' is not assignable to type 'import('discord.js-modules/node_modules/@types/node-fetch/externals').AbortSignal'
@@ -125,12 +127,13 @@ export class SequentialHandler implements IHandler {
 			clearTimeout(timeout);
 		}
 
+		void this.manager.debug(`[${url} Response] - ${JSON.stringify(res)}`);
+
 		if (res.ok) {
 			const parsedRes = await SequentialHandler.parseResponse(res);
 			return parsedRes;
 		} else if (res.status === 400 || res.status === 401 || res.status === 404) {
 			const parsedRes = await SequentialHandler.parseResponse(res);
-			// throw new HTTPError(String(parsedRes), res.constructor.name, res.status, data.method, url);
 			throw new APIError(parsedRes as string, data.type, data.fullUrl, res.status, data);
 		} else if (res.status === 429) {
 			const timeout = setTimeout(() => {


### PR DESCRIPTION
Debug has been an option with S.JS since day 1 but hasn't actually had any debug logs associated with it. This change implements two beneficial logs upon queued requests, one upon the initial request and one once the response is received. All information/data is logged within this.