### PR TITLE
fix: Documentation (readme) fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ Sonoran.js is a library that allows you to interact with the [Sonoran CAD](https
 
 Utilizing both Sonoran CMS & Sonoran CAD
 ```js
-const Sonoran = require('sonoran.js');
-const instance = Sonoran.instance({
+const Sonoran = require('@sonoransoftware/sonoran.js');
+const instance = new Sonoran.Instance({
   cadCommunityId: 'mycommunity',
   cadApiKey: 'DF58F1E-FD8A-44C5-BA',
   cmsCommunityId: 'mycommunity',
@@ -16,8 +16,8 @@ const instance = Sonoran.instance({
 
 Utilizing just Sonoran CMS or Sonoran CAD
 ```js
-const Sonoran = require('sonoran.js');
-const instance = Sonoran.instance({
+const Sonoran = require('@sonoransoftware/sonoran.js');
+const instance = new Sonoran.Instance({
   communityId: 'mycommunity',
   apiKey: 'e6ba9d68-ca7a-4e59-a9e2-93e275b4e0bf',
   product: Sonoran.productEnums.CMS
@@ -26,8 +26,8 @@ const instance = Sonoran.instance({
 
 ## Example Method Usage
 ```js
-const Sonoran = require('sonoran.js');
-const instance = Sonoran.instance({
+const Sonoran = require('@sonoransoftware/sonoran.js');
+const instance = new Sonoran.Instance({
   communityId: 'mycommunity',
   apiKey: 'e6ba9d68-ca7a-4e59-a9e2-93e275b4e0bf',
   product: Sonoran.productEnums.CMS,


### PR DESCRIPTION
- The module name in the docs should include @sonoransoftware/ for npmjs
- sonoran.Instance is capital I 
- sonoran.Instance is a constructor
